### PR TITLE
fix: Add input validation for security group creation

### DIFF
--- a/module-metadata.json
+++ b/module-metadata.json
@@ -572,7 +572,7 @@
       },
       "pos": {
         "filename": "security_group.tf",
-        "line": 26
+        "line": 30
       }
     },
     "ibm_is_security_group_rule.security_group_rules": {
@@ -584,7 +584,7 @@
       },
       "pos": {
         "filename": "security_group.tf",
-        "line": 63
+        "line": 65
       }
     },
     "ibm_is_volume.volume": {

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,7 +12,7 @@ output "ids" {
 
 output "vsi_security_group" {
   description = "Security group for the VSI"
-  value       = var.security_group == null ? null : ibm_is_security_group.security_group[var.security_group.name]
+  value       = var.security_group != null && var.create_security_group == true ? ibm_is_security_group.security_group[var.security_group.name] : null
 }
 
 output "list" {

--- a/security_group.tf
+++ b/security_group.tf
@@ -21,6 +21,10 @@ locals {
     for group in local.security_groups :
     (group.name) => group
   }
+
+  # input variable validation
+  # tflint-ignore: terraform_unused_declarations
+  validate_security_group = var.create_security_group == false && var.security_group != null ? tobool("A value can not be set for var.security_group when var.create_security_group is false. Use var.security_group_ids to add security groups to VSI deployment primary interface") : true
 }
 
 resource "ibm_is_security_group" "security_group" {
@@ -57,8 +61,6 @@ locals {
     ("${rule.sg_name}-${rule.name}") => rule
   }
 }
-
-
 
 resource "ibm_is_security_group_rule" "security_group_rules" {
   for_each  = local.security_group_rules


### PR DESCRIPTION
### Description

The user incorrectly used SGs with VSI. He wanted to attach existing SG with a new VSI using `var.create_security_group=false` and set value of `var.security_group`.

Therefore, the output error occurred. 

Instead, to append existing SG to VSI `var.security_group_ids` needs to be used. 

To prevent this behavior new input validation was added which checks if `var.create_security_group=false` then `var.security_group` shouldn't have the value.
In addition extra check was added to `vsi_security_group` output to prevent error to occur again.
 
### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
