### PR TITLE
fix: don't attach default sg

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -123,8 +123,8 @@ resource "ibm_is_instance" "vsi" {
     subnet = each.value.subnet_id
     security_groups = flatten([
       (var.create_security_group ? [ibm_is_security_group.security_group[var.security_group.name].id] : []),
-      (var.security_group_ids != null ? var.security_group_ids : []),
-      (var.create_security_group == false && var.security_group_ids == null ? [local.default_security_group_id] : []),
+      var.security_group_ids,
+      (var.create_security_group == false && length(var.security_group_ids) == 0 ? [local.default_security_group_id] : []),
     ])
     allow_ip_spoofing = var.allow_ip_spoofing
   }

--- a/main.tf
+++ b/main.tf
@@ -122,8 +122,9 @@ resource "ibm_is_instance" "vsi" {
   primary_network_interface {
     subnet = each.value.subnet_id
     security_groups = flatten([
-      (var.create_security_group ? [ibm_is_security_group.security_group[var.security_group.name].id] : [local.default_security_group_id]),
-      var.security_group_ids
+      (var.create_security_group ? [ibm_is_security_group.security_group[var.security_group.name].id] : []),
+      (var.security_group_ids != null ? var.security_group_ids : []),
+      (var.create_security_group == false && var.security_group_ids == null ? [local.default_security_group_id] : []),
     ])
     allow_ip_spoofing = var.allow_ip_spoofing
   }

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -468,7 +468,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 175
+        "line": 183
       }
     },
     "ibm_is_floating_ip.vsi_fip": {
@@ -485,7 +485,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 167
+        "line": 175
       }
     },
     "ibm_is_instance.vsi": {

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -468,7 +468,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 174
+        "line": 175
       }
     },
     "ibm_is_floating_ip.vsi_fip": {
@@ -485,7 +485,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 166
+        "line": 167
       }
     },
     "ibm_is_instance.vsi": {


### PR DESCRIPTION
### Description

Do not attach default security group to vsi when `security_group_ids` is defined.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

If a value is passed for `security_group_ids`, the module will no longer assign the default security group to the VSI, just the ones passed in the `security_group_ids` list. If `create_security_group` is set to false, then the default security group will be attached.<br>NOTE: If upgrading from a previous version, and passing in a value for `security_group_ids`, the module will do an update in place to remove the default security group from the VSI.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
