### PR TITLE
Simplify default security group lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ No modules.
 | [ibm_is_volume.volume](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/is_volume) | resource |
 | [time_sleep.wait_for_authorization_policy](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [ibm_is_vpc.vpc](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/is_vpc) | data source |
-| [ibm_is_vpcs.vpcs](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/is_vpcs) | data source |
 
 ### Inputs
 

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -348,7 +348,7 @@
       "description": "ID of VPC",
       "required": true,
       "source": [
-        "data.ibm_is_vpcs.vpcs.depends_on",
+        "data.ibm_is_vpc.vpc.identifier",
         "ibm_is_instance.vsi.vpc",
         "ibm_is_security_group.security_group.vpc"
       ],
@@ -451,7 +451,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 94
+        "line": 83
       }
     },
     "ibm_is_floating_ip.secondary_fip": {
@@ -468,7 +468,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 182
+        "line": 169
       }
     },
     "ibm_is_floating_ip.vsi_fip": {
@@ -485,7 +485,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 174
+        "line": 161
       }
     },
     "ibm_is_instance.vsi": {
@@ -509,7 +509,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 103
+        "line": 92
       }
     },
     "ibm_is_lb.lb": {
@@ -634,20 +634,8 @@
       "mode": "data",
       "type": "ibm_is_vpc",
       "name": "vpc",
-      "provider": {
-        "name": "ibm"
-      },
-      "pos": {
-        "filename": "main.tf",
-        "line": 78
-      }
-    },
-    "data.ibm_is_vpcs.vpcs": {
-      "mode": "data",
-      "type": "ibm_is_vpcs",
-      "name": "vpcs",
       "attributes": {
-        "depends_on": "vpc_id"
+        "identifier": "vpc_id"
       },
       "provider": {
         "name": "ibm"

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -468,7 +468,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 183
+        "line": 170
       }
     },
     "ibm_is_floating_ip.vsi_fip": {
@@ -485,7 +485,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 175
+        "line": 162
       }
     },
     "ibm_is_instance.vsi": {


### PR DESCRIPTION
### Description

To address internal issue 6157. The lookup of the default security group is unnecessarily complex. Avoid looking up all VPCs and finding the right one based on the supplied vpc_id. Just look up the one VPC using the vpc_id.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

There are no resource changes, so no impact to customers.

It is possible that the data resource for all VPC may show as being removed from the state file. However, as a data resource there are no resource changes.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
