### PR TITLE
test: enable fscloud tests

### DIFF
--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -80,9 +80,10 @@ func setupFSCloudOptions(t *testing.T, prefix string) *testhelper.TestOptions {
 		ResourceGroup: resourceGroup,
 		Region:        region,
 		TerraformVars: map[string]interface{}{
-			"existing_kms_instance_guid": permanentResources["hpcs_south"],
-			"boot_volume_encryption_key": permanentResources["hpcs_south_root_key_crn"],
-			"access_tags":                permanentResources["accessTags"],
+			"skip_iam_authorization_policy": true, // The test account already has got a s2s policy setup that would clash
+			"existing_kms_instance_guid":    permanentResources["hpcs_south"],
+			"boot_volume_encryption_key":    permanentResources["hpcs_south_root_key_crn"],
+			"access_tags":                   permanentResources["accessTags"],
 		},
 	})
 
@@ -90,7 +91,6 @@ func setupFSCloudOptions(t *testing.T, prefix string) *testhelper.TestOptions {
 }
 
 func TestRunFSCloudExample(t *testing.T) {
-	t.Skip() // Skip until we can run in own account. See discussions in https://github.com/terraform-ibm-modules/terraform-ibm-landing-zone-vsi/pull/569
 	t.Parallel()
 
 	options := setupFSCloudOptions(t, "slz-vsi-fscloud")


### PR DESCRIPTION
### Description

* Re-enable FSCloud tests
* add "skip_iam_authorization_policy" set to True in the FSCloud test.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
