### PR TITLE
fix: add float ip properties to full output list

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -26,6 +26,8 @@ output "list" {
       ipv4_address           = virtual_server.primary_network_interface[0].primary_ipv4_address
       secondary_ipv4_address = length(virtual_server.network_interfaces) == 0 ? null : virtual_server.network_interfaces[0].primary_ipv4_address
       floating_ip            = var.enable_floating_ip ? ibm_is_floating_ip.vsi_fip[vsi_key].address : null
+      floating_ip_id         = var.enable_floating_ip ? ibm_is_floating_ip.vsi_fip[vsi_key].id : null
+      floating_ip_crn        = var.enable_floating_ip ? ibm_is_floating_ip.vsi_fip[vsi_key].crn : null
       vpc_id                 = var.vpc_id
     }
   ]

--- a/outputs.tf
+++ b/outputs.tf
@@ -42,6 +42,8 @@ output "fip_list" {
       ipv4_address           = virtual_server.primary_network_interface[0].primary_ipv4_address
       secondary_ipv4_address = length(virtual_server.network_interfaces) == 0 ? null : virtual_server.network_interfaces[0].primary_ipv4_address
       floating_ip            = var.enable_floating_ip ? ibm_is_floating_ip.vsi_fip[vsi_key].address : null
+      floating_ip_id         = var.enable_floating_ip ? ibm_is_floating_ip.vsi_fip[vsi_key].id : null
+      floating_ip_crn        = var.enable_floating_ip ? ibm_is_floating_ip.vsi_fip[vsi_key].crn : null
       vpc_id                 = var.vpc_id
     } if var.enable_floating_ip == true
   ]


### PR DESCRIPTION
### Description

Added the following properties to the full vsi list output map (missed when adding to floating ip list map):
* floating_ip_id
* floating_ip_crn

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Added the following properties to the full vsi list output map:
* floating_ip_id
* floating_ip_crn

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
