### PR TITLE
fix: update the default VSI image IDs

### DIFF
--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -37,7 +37,7 @@ variable "access_tags" {
 variable "image_id" {
   description = "Image ID used for VSI. Run 'ibmcloud is images' to find available images. Be aware that region is important for the image since the id's are different in each region."
   type        = string
-  default     = "r006-a8ea37e8-6c25-4b1e-a252-a1faa16de0d7"
+  default     = "r006-8899f638-cfbf-4131-9ab4-0656fe73abaf"
 }
 
 variable "machine_type" {

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -37,7 +37,7 @@ variable "access_tags" {
 variable "image_id" {
   description = "Image ID used for VSI. Run 'ibmcloud is images' to find available images. Be aware that region is important for the image since the id's are different in each region."
   type        = string
-  default     = "r006-a8ea37e8-6c25-4b1e-a252-a1faa16de0d7"
+  default     = "r006-8899f638-cfbf-4131-9ab4-0656fe73abaf"
 }
 
 variable "ssh_key" {

--- a/examples/fscloud/variables.tf
+++ b/examples/fscloud/variables.tf
@@ -31,7 +31,7 @@ variable "resource_tags" {
 variable "image_id" {
   description = "Image ID used for VSI. Run 'ibmcloud is images' to find available images in a region"
   type        = string
-  default     = "r006-a8ea37e8-6c25-4b1e-a252-a1faa16de0d7"
+  default     = "r006-8899f638-cfbf-4131-9ab4-0656fe73abaf"
 }
 
 variable "machine_type" {

--- a/examples/snapshot/variables.tf
+++ b/examples/snapshot/variables.tf
@@ -37,7 +37,7 @@ variable "access_tags" {
 variable "image_id" {
   description = "Image ID used for VSI. Run 'ibmcloud is images' to find available images. Be aware that region is important for the image since the id's are different in each region."
   type        = string
-  default     = "r014-2a39e91e-e899-4ac4-b309-57e107a7819f" # NOTE: this ID is for us-east region, Redhat 8.10 minimal
+  default     = "r014-e270d889-f4c6-4d48-8910-026756aaecc4" # NOTE: this ID is for us-east region, Redhat 8.10 minimal
 }
 
 variable "machine_type" {


### PR DESCRIPTION
Update VSI image name variable defaults to ibm-redhat-9-4-minimal-amd64-3