### PR TITLE
chore: update the default VSI image IDs

### DIFF
--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -37,7 +37,7 @@ variable "access_tags" {
 variable "image_id" {
   description = "Image ID used for VSI. Run 'ibmcloud is images' to find available images. Be aware that region is important for the image since the id's are different in each region."
   type        = string
-  default     = "r006-0b7c7439-70c7-4c29-98df-52759b012f63"
+  default     = "r006-cc341965-a523-464e-969f-391e2661c125"
 }
 
 variable "machine_type" {

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -37,7 +37,7 @@ variable "access_tags" {
 variable "image_id" {
   description = "Image ID used for VSI. Run 'ibmcloud is images' to find available images. Be aware that region is important for the image since the id's are different in each region."
   type        = string
-  default     = "r006-0b7c7439-70c7-4c29-98df-52759b012f63"
+  default     = "r006-cc341965-a523-464e-969f-391e2661c125"
 }
 
 variable "ssh_key" {

--- a/examples/fscloud/variables.tf
+++ b/examples/fscloud/variables.tf
@@ -31,7 +31,7 @@ variable "resource_tags" {
 variable "image_id" {
   description = "Image ID used for VSI. Run 'ibmcloud is images' to find available images in a region"
   type        = string
-  default     = "r006-0b7c7439-70c7-4c29-98df-52759b012f63"
+  default     = "r006-cc341965-a523-464e-969f-391e2661c125"
 }
 
 variable "machine_type" {

--- a/examples/snapshot/variables.tf
+++ b/examples/snapshot/variables.tf
@@ -37,7 +37,7 @@ variable "access_tags" {
 variable "image_id" {
   description = "Image ID used for VSI. Run 'ibmcloud is images' to find available images. Be aware that region is important for the image since the id's are different in each region."
   type        = string
-  default     = "r014-ebe2f66f-ded9-4e53-a95e-0abfd6d09ec4" # NOTE: this ID is for us-east region, Redhat 8.10 minimal
+  default     = "r014-9e2200eb-232c-4392-9dab-3ca6468d522c" # NOTE: this ID is for us-east region, Redhat 8.10 minimal
 }
 
 variable "machine_type" {


### PR DESCRIPTION
Update VSI image name variable defaults to ibm-redhat-9-4-minimal-amd64-6