### PR TITLE
fix: disabled dedicated host

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -9,6 +9,9 @@ It will provision the following:
 - A VSI in each subnet placed in the placement group.
 - A floating IP for each virtual server created.
 - A secondary VSI with secondary subnets and secondary security group.
-- A dedicated host and a dedicated host group.
-- A VSI will be created on the dedicated host.
+- **(Optional) A dedicated host and a dedicated host group.** - Disabled by default.
+- **(Optional) A VSI will be created on the dedicated host if enabled.**
 - A new Application Load Balancer and Network Load Balancer to balance traffic between all virtual servers that are created by this example.
+
+
+> Note: The Dedicated Host module is disabled by default . If you need to deploy a dedicated host, you must explicitly enable it by setting `enable_dedicated_host = true`

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -245,6 +245,7 @@ module "slz_vsi" {
 #############################################################################
 
 module "dedicated_host" {
+  count   = var.enable_dedicated_host ? 1 : 0
   source  = "terraform-ibm-modules/dedicated-host/ibm"
   version = "1.1.0"
   dedicated_hosts = [
@@ -270,6 +271,9 @@ module "dedicated_host" {
 #############################################################################
 
 module "slz_vsi_dh" {
+  # depends_on                    = [module.dedicated_host]
+  # dedicated_host_id               = module.dedicated_host.dedicated_host_ids[0]
+  skip_iam_authorization_policy   = true
   source                          = "../../"
   resource_group_id               = module.resource_group.resource_group_id
   image_id                        = var.image_id
@@ -279,7 +283,6 @@ module "slz_vsi_dh" {
   subnets                         = [for subnet in module.slz_vpc.subnet_zone_list : subnet if subnet.zone == "${var.region}-1"]
   vpc_id                          = module.slz_vpc.vpc_id
   prefix                          = "${var.prefix}-dh"
-  dedicated_host_id               = module.dedicated_host.dedicated_host_ids[0]
   machine_type                    = "bx2-2x8"
   user_data                       = null
   boot_volume_encryption_key      = module.key_protect_all_inclusive.keys["slz-vsidh.${var.prefix}-vsidh"].crn
@@ -298,6 +301,4 @@ module "slz_vsi_dh" {
       name    = "${var.prefix}-dh"
       profile = "10iops-tier"
   }]
-  skip_iam_authorization_policy = true
-  depends_on                    = [module.dedicated_host]
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -272,8 +272,7 @@ module "dedicated_host" {
 
 module "slz_vsi_dh" {
   count                           = var.enable_dedicated_host ? 1 : 0
-  depends_on                      = [module.dedicated_host]
-  dedicated_host_id               = try(module.dedicated_host.dedicated_host_ids[0], null)
+  dedicated_host_id               = var.enable_dedicated_host ? module.dedicated_host.dedicated_host_ids[0] : null
   source                          = "../../"
   resource_group_id               = module.resource_group.resource_group_id
   image_id                        = var.image_id

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -271,8 +271,8 @@ module "dedicated_host" {
 #############################################################################
 
 module "slz_vsi_dh" {
-  # depends_on                    = [module.dedicated_host]
-  # dedicated_host_id               = module.dedicated_host.dedicated_host_ids[0]
+  depends_on                      = [module.dedicated_host]
+  dedicated_host_id               = var.enable_dedicated_host ? try(module.dedicated_host.dedicated_host_ids[0], null) : null
   skip_iam_authorization_policy   = true
   source                          = "../../"
   resource_group_id               = module.resource_group.resource_group_id

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -271,8 +271,9 @@ module "dedicated_host" {
 #############################################################################
 
 module "slz_vsi_dh" {
+  count                           = var.enable_dedicated_host ? 1 : 0
   depends_on                      = [module.dedicated_host]
-  dedicated_host_id               = var.enable_dedicated_host ? try(module.dedicated_host.dedicated_host_ids[0], null) : null
+  dedicated_host_id               = try(module.dedicated_host.dedicated_host_ids[0], null)
   skip_iam_authorization_policy   = true
   source                          = "../../"
   resource_group_id               = module.resource_group.resource_group_id

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -274,7 +274,6 @@ module "slz_vsi_dh" {
   count                           = var.enable_dedicated_host ? 1 : 0
   depends_on                      = [module.dedicated_host]
   dedicated_host_id               = try(module.dedicated_host.dedicated_host_ids[0], null)
-  skip_iam_authorization_policy   = true
   source                          = "../../"
   resource_group_id               = module.resource_group.resource_group_id
   image_id                        = var.image_id

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -25,7 +25,7 @@ variable "prefix" {
 variable "resource_tags" {
   description = "List of Tags for the resource created"
   type        = list(string)
-  default     = null
+  default     = []
 }
 
 variable "access_tags" {
@@ -50,4 +50,10 @@ variable "secondary_use_vsi_security_group" {
   description = "Use the security group created by this module in the secondary interface"
   type        = bool
   default     = false
+}
+
+variable "enable_dedicated_host" {
+  type        = bool
+  default     = false
+  description = "Enabling this option will activate dedicated hosts for the VSIs. When enabled, the dedicated_host_id input is required. The default value is set to false. Refer [Understanding Dedicated Hosts](https://cloud.ibm.com/docs/vpc?topic=vpc-creating-dedicated-hosts-instances&interface=ui#about-dedicated-hosts) for more details"
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -55,5 +55,5 @@ variable "secondary_use_vsi_security_group" {
 variable "enable_dedicated_host" {
   type        = bool
   default     = false
-  description = "Set the flag to true to provision a dedicated host and deploy VSIs on it. When disabled (default), VSIs will be created on shared hosts instead. Refer [Understanding Dedicated Hosts](https://cloud.ibm.com/docs/vpc?topic=vpc-creating-dedicated-hosts-instances&interface=ui#about-dedicated-hosts) for more details."
+  description = "Set the flag to true to provision a dedicated host and deploy VSIs on it. The default value is set to false. Refer [Understanding Dedicated Hosts](https://cloud.ibm.com/docs/vpc?topic=vpc-creating-dedicated-hosts-instances&interface=ui#about-dedicated-hosts) for more details."
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -55,5 +55,5 @@ variable "secondary_use_vsi_security_group" {
 variable "enable_dedicated_host" {
   type        = bool
   default     = false
-  description = "Enabling this option will activate dedicated hosts for the VSIs. When enabled, the dedicated_host_id input is required. The default value is set to false. Refer [Understanding Dedicated Hosts](https://cloud.ibm.com/docs/vpc?topic=vpc-creating-dedicated-hosts-instances&interface=ui#about-dedicated-hosts) for more details"
+  description = "Set the flag to true to provision a dedicated host and deploy VSIs on it. When disabled (default), VSIs will be created on shared hosts instead. Refer [Understanding Dedicated Hosts](https://cloud.ibm.com/docs/vpc?topic=vpc-creating-dedicated-hosts-instances&interface=ui#about-dedicated-hosts) for more details."
 }


### PR DESCRIPTION
### Description

This PR is to unblock the pipeline tests by disabling the dedicated host changes that are causing errors.
Refer Issue- [12711](https://github.ibm.com/GoldenEye/issues/issues/12711) for more details.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

* Disabled dedicated host changes to unblock pipeline tests.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
