### PR TITLE
fix: duplicate naming issue for vsi related resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This module creates Virtual Server Instances (VSI) across multiple subnets with 
     * [Basic example using a Snapshot Consistency Group for volumes](./examples/snapshot)
     * [Complete Example using a placement group, attaching a load balancer, creating secondary interface, and adding additional data volumes](./examples/complete)
     * [End to end basic example](./examples/basic)
+    * [Example demonstrating the deployment of different sets of VSIs (with different machine types) to the same VPC and subnets, empoying two calls to the module.](./examples/multi-profile-one-vpc)
     * [Financial Services Cloud profile example](./examples/fscloud)
 * [Contributing](#contributing)
 <!-- END OVERVIEW HOOK -->

--- a/examples/multi-profile-one-vpc/README.md
+++ b/examples/multi-profile-one-vpc/README.md
@@ -1,0 +1,14 @@
+# Example demonstrating the deployment of different sets of VSIs (with different machine types) to the same VPC and subnets, empoying two calls to the module.
+
+It will provision the following:
+
+- A new resource group if one is not passed in.
+- A new public SSH key if one is not passed in.
+- A new VPC with 3 subnets.
+- Two sets of virtual servers, one set with `cx` machine type, one set with `bx`, deployed to the same VPC and subnets
+- Each of the virtual server sets will deploy the following:
+    - A VSI in each subnet.
+    - A managed reserved IP for each virtual server created.
+    - A floating IP for each virtual server created.
+    - A secondary VSI with secondary subnets and secondary security group.
+    - A new Application Load Balancer and Network Load Balancer to balance traffic between all virtual servers that are created by this example.

--- a/examples/multi-profile-one-vpc/main.tf
+++ b/examples/multi-profile-one-vpc/main.tf
@@ -1,0 +1,364 @@
+##############################################################################
+# Locals
+##############################################################################
+
+locals {
+  ssh_key_id = var.ssh_key != null ? data.ibm_is_ssh_key.existing_ssh_key[0].id : resource.ibm_is_ssh_key.ssh_key[0].id
+}
+
+##############################################################################
+# Resource Group
+##############################################################################
+
+module "resource_group" {
+  source  = "terraform-ibm-modules/resource-group/ibm"
+  version = "1.2.1"
+  # if an existing resource group is not set (null) create a new one using prefix
+  resource_group_name          = var.resource_group == null ? "${var.prefix}-resource-group" : null
+  existing_resource_group_name = var.resource_group
+}
+
+##############################################################################
+# Key Protect All Inclusive
+##############################################################################
+
+module "key_protect_all_inclusive" {
+  source                    = "terraform-ibm-modules/kms-all-inclusive/ibm"
+  version                   = "5.1.11"
+  resource_group_id         = module.resource_group.resource_group_id
+  region                    = var.region
+  key_protect_instance_name = "${var.prefix}-kp"
+  resource_tags             = var.resource_tags
+  keys = [
+    {
+      key_ring_name = "slz-vsi"
+      keys = [
+        {
+          key_name     = "${var.prefix}-vsi"
+          force_delete = true
+        }
+      ]
+    }
+  ]
+}
+
+module "existing_boot_volume_kms_key_crn_parser" {
+  source  = "terraform-ibm-modules/common-utilities/ibm//modules/crn-parser"
+  version = "1.2.0"
+  crn     = module.key_protect_all_inclusive.keys["slz-vsi.${var.prefix}-vsi"].crn
+}
+
+locals {
+  existing_kms_guid = module.existing_boot_volume_kms_key_crn_parser.service_instance
+  kms_service_name  = module.existing_boot_volume_kms_key_crn_parser.service_name
+  kms_account_id    = module.existing_boot_volume_kms_key_crn_parser.account_id
+  kms_key_id        = module.existing_boot_volume_kms_key_crn_parser.resource
+}
+
+# NOTE: The below auth policy cannot be scoped to a source resource group due to
+# the fact that the Block storage volume does not yet exist in the resource group.
+resource "ibm_iam_authorization_policy" "block_storage_policy" {
+  source_service_name = "server-protect"
+  roles               = ["Reader"]
+  description         = "Allow block storage volumes to read the ${local.kms_service_name} key ${local.kms_key_id} from the instance ${local.existing_kms_guid}"
+  resource_attributes {
+    name     = "serviceName"
+    operator = "stringEquals"
+    value    = local.kms_service_name
+  }
+  resource_attributes {
+    name     = "accountId"
+    operator = "stringEquals"
+    value    = local.kms_account_id
+  }
+  resource_attributes {
+    name     = "serviceInstance"
+    operator = "stringEquals"
+    value    = local.existing_kms_guid
+  }
+  resource_attributes {
+    name     = "resourceType"
+    operator = "stringEquals"
+    value    = "key"
+  }
+  resource_attributes {
+    name     = "resource"
+    operator = "stringEquals"
+    value    = local.kms_key_id
+  }
+  # Scope of policy now includes the key, so ensure to create new policy before
+  # destroying old one to prevent any disruption to every day services.
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+##############################################################################
+# Create new SSH key
+##############################################################################
+
+resource "tls_private_key" "tls_key" {
+  count     = var.ssh_key != null ? 0 : 1
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "ibm_is_ssh_key" "ssh_key" {
+  count      = var.ssh_key != null ? 0 : 1
+  name       = "${var.prefix}-ssh-key"
+  public_key = resource.tls_private_key.tls_key[0].public_key_openssh
+}
+
+data "ibm_is_ssh_key" "existing_ssh_key" {
+  count = var.ssh_key != null ? 1 : 0
+  name  = var.ssh_key
+}
+
+#############################################################################
+# Provision VPC
+#############################################################################
+
+module "slz_vpc" {
+  source            = "terraform-ibm-modules/landing-zone-vpc/ibm"
+  version           = "7.25.10"
+  resource_group_id = module.resource_group.resource_group_id
+  region            = var.region
+  prefix            = var.prefix
+  tags              = var.resource_tags
+  name              = "vpc"
+}
+
+#############################################################################
+# Provision Secondary Subnets
+#############################################################################
+
+locals {
+  secondary_subnet_map = {
+    "${var.prefix}-second-subnet-a" = {
+      zone = "${var.region}-1"
+      cidr = "10.10.20.0/24"
+    }
+    "${var.prefix}-second-subnet-b" = {
+      zone = "${var.region}-2"
+      cidr = "10.20.20.0/24"
+    }
+    "${var.prefix}-second-subnet-c" = {
+      zone = "${var.region}-3"
+      cidr = "10.30.20.0/24"
+    }
+  }
+}
+
+resource "ibm_is_vpc_address_prefix" "secondary_address_prefixes" {
+  for_each = local.secondary_subnet_map
+  name     = "${each.key}-prefix"
+  vpc      = module.slz_vpc.vpc_id
+  zone     = each.value.zone
+  cidr     = each.value.cidr
+}
+
+resource "ibm_is_subnet" "secondary_subnet" {
+  depends_on      = [ibm_is_vpc_address_prefix.secondary_address_prefixes]
+  for_each        = local.secondary_subnet_map
+  ipv4_cidr_block = each.value.cidr
+  name            = each.key
+  vpc             = module.slz_vpc.vpc_id
+  zone            = each.value.zone
+}
+
+#############################################################################
+# Provision Secondary Security Groups
+#############################################################################
+
+locals {
+  secondary_security_groups = [
+    for subnet in module.slz_vpc.subnet_zone_list : {
+      security_group_id = ibm_is_security_group.secondary_security_group.id
+      interface_name    = "secondary-subnet-${subnet.zone}"
+    }
+  ]
+}
+
+resource "ibm_is_security_group" "secondary_security_group" {
+  name = "${var.prefix}-sg"
+  vpc  = module.slz_vpc.vpc_id
+}
+
+#############################################################################
+# Provision VSI
+#############################################################################
+
+locals {
+  secondary_subnet_zone_list = [
+    for subnet in ibm_is_subnet.secondary_subnet : {
+      name = subnet.name
+      id   = subnet.id
+      zone = subnet.zone
+      cidr = subnet.ipv4_cidr_block
+    }
+  ]
+  custom_vsi_volume_names = {
+    for idx, subnet in module.slz_vpc.subnet_zone_list : subnet.name =>
+    {
+      "${subnet.name}-vsi-name-1" = ["${subnet.name}-vol-1a"]
+    }
+  }
+}
+
+#############################################################################
+# First VSI on cx2
+#############################################################################
+
+module "slz_vsi_cx" {
+  depends_on                      = [module.slz_vpc]
+  source                          = "../../"
+  resource_group_id               = module.resource_group.resource_group_id
+  image_id                        = var.image_id
+  create_security_group           = false
+  tags                            = var.resource_tags
+  access_tags                     = var.access_tags
+  subnets                         = module.slz_vpc.subnet_zone_list
+  vpc_id                          = module.slz_vpc.vpc_id
+  prefix                          = "${var.prefix}-cx"
+  machine_type                    = "cx2-2x4"
+  user_data                       = null
+  boot_volume_encryption_key      = module.key_protect_all_inclusive.keys["slz-vsi.${var.prefix}-vsi"].crn
+  skip_iam_authorization_policy   = true # is done globally above
+  use_static_boot_volume_name     = true
+  boot_volume_size                = 150
+  kms_encryption_enabled          = true
+  vsi_per_subnet                  = 1
+  primary_vni_additional_ip_count = 2
+  manage_reserved_ips             = true
+
+  ssh_key_ids               = [local.ssh_key_id]
+  secondary_subnets         = local.secondary_subnet_zone_list
+  secondary_security_groups = local.secondary_security_groups
+
+  # Create a floating IPs for the additional VNI
+  secondary_floating_ips = [
+    for subnet in local.secondary_subnet_zone_list :
+    subnet.name
+  ]
+
+  # Create a floating IP for each virtual server created
+  enable_floating_ip               = true
+  secondary_use_vsi_security_group = true
+
+  # Add 1 additional data volume to each VSI
+  block_storage_volumes = [
+    {
+      name    = var.prefix
+      profile = "10iops-tier"
+  }]
+  load_balancers = [
+    {
+      name                    = "${var.prefix}-cx-lb"
+      type                    = "public"
+      listener_port           = 9080
+      listener_protocol       = "http"
+      connection_limit        = 100
+      idle_connection_timeout = 50
+      algorithm               = "round_robin"
+      protocol                = "http"
+      health_delay            = 60
+      health_retries          = 5
+      health_timeout          = 30
+      health_type             = "http"
+      pool_member_port        = 8080
+    },
+    {
+      name              = "${var.prefix}-cx-nlb"
+      type              = "public"
+      profile           = "network-fixed"
+      listener_port     = 3128
+      listener_protocol = "tcp"
+      algorithm         = "round_robin"
+      protocol          = "tcp"
+      health_delay      = 60
+      health_retries    = 5
+      health_timeout    = 30
+      health_type       = "tcp"
+      pool_member_port  = 3120
+    }
+  ]
+}
+
+#############################################################################
+# Second VSI with Placement Group on bx2
+#############################################################################
+
+module "slz_vsi_bx" {
+  depends_on                      = [module.slz_vpc]
+  source                          = "../../"
+  resource_group_id               = module.resource_group.resource_group_id
+  image_id                        = var.image_id
+  create_security_group           = false
+  tags                            = var.resource_tags
+  access_tags                     = var.access_tags
+  subnets                         = module.slz_vpc.subnet_zone_list
+  vpc_id                          = module.slz_vpc.vpc_id
+  prefix                          = "${var.prefix}-bx"
+  machine_type                    = "bx2-2x8"
+  user_data                       = null
+  boot_volume_encryption_key      = module.key_protect_all_inclusive.keys["slz-vsi.${var.prefix}-vsi"].crn
+  skip_iam_authorization_policy   = true # is done globally above
+  use_static_boot_volume_name     = true
+  boot_volume_size                = 150
+  kms_encryption_enabled          = true
+  vsi_per_subnet                  = 1
+  primary_vni_additional_ip_count = 2
+  manage_reserved_ips             = true
+
+  ssh_key_ids               = [local.ssh_key_id]
+  secondary_subnets         = local.secondary_subnet_zone_list
+  secondary_security_groups = local.secondary_security_groups
+
+  # Create a floating IPs for the additional VNI
+  secondary_floating_ips = [
+    for subnet in local.secondary_subnet_zone_list :
+    subnet.name
+  ]
+
+  # Create a floating IP for each virtual server created
+  enable_floating_ip               = true
+  secondary_use_vsi_security_group = true
+
+  # Add 1 additional data volume to each VSI
+  block_storage_volumes = [
+    {
+      name    = var.prefix
+      profile = "10iops-tier"
+  }]
+  load_balancers = [
+    {
+      name                    = "${var.prefix}-bx-lb"
+      type                    = "public"
+      listener_port           = 9080
+      listener_protocol       = "http"
+      connection_limit        = 100
+      idle_connection_timeout = 50
+      algorithm               = "round_robin"
+      protocol                = "http"
+      health_delay            = 60
+      health_retries          = 5
+      health_timeout          = 30
+      health_type             = "http"
+      pool_member_port        = 8080
+    },
+    {
+      name              = "${var.prefix}-bx-nlb"
+      type              = "public"
+      profile           = "network-fixed"
+      listener_port     = 3128
+      listener_protocol = "tcp"
+      algorithm         = "round_robin"
+      protocol          = "tcp"
+      health_delay      = 60
+      health_retries    = 5
+      health_timeout    = 30
+      health_type       = "tcp"
+      pool_member_port  = 3120
+    }
+  ]
+}

--- a/examples/multi-profile-one-vpc/main.tf
+++ b/examples/multi-profile-one-vpc/main.tf
@@ -164,6 +164,7 @@ resource "ibm_is_subnet" "secondary_subnet" {
   name            = each.key
   vpc             = module.slz_vpc.vpc_id
   zone            = each.value.zone
+  resource_group  = module.resource_group.resource_group_id
 }
 
 #############################################################################
@@ -180,8 +181,9 @@ locals {
 }
 
 resource "ibm_is_security_group" "secondary_security_group" {
-  name = "${var.prefix}-sg"
-  vpc  = module.slz_vpc.vpc_id
+  name           = "${var.prefix}-sg"
+  vpc            = module.slz_vpc.vpc_id
+  resource_group = module.resource_group.resource_group_id
 }
 
 #############################################################################
@@ -197,12 +199,6 @@ locals {
       cidr = subnet.ipv4_cidr_block
     }
   ]
-  custom_vsi_volume_names = {
-    for idx, subnet in module.slz_vpc.subnet_zone_list : subnet.name =>
-    {
-      "${subnet.name}-vsi-name-1" = ["${subnet.name}-vol-1a"]
-    }
-  }
 }
 
 #############################################################################

--- a/examples/multi-profile-one-vpc/outputs.tf
+++ b/examples/multi-profile-one-vpc/outputs.tf
@@ -1,0 +1,24 @@
+output "slz_vpc" {
+  value       = module.slz_vpc
+  description = "VPC module values"
+}
+
+output "slz_vsi_cx" {
+  value       = module.slz_vsi_cx
+  description = "VSI cx profile module values"
+}
+
+output "slz_vsi_bx" {
+  value       = module.slz_vsi_bx
+  description = "VSI bx profile module values"
+}
+
+output "secondary_subnets" {
+  description = "Secondary subnets created"
+  value       = local.secondary_subnet_zone_list
+}
+
+output "secondary_security_groups" {
+  description = "Secondary security groups created"
+  value       = local.secondary_security_groups
+}

--- a/examples/multi-profile-one-vpc/provider.tf
+++ b/examples/multi-profile-one-vpc/provider.tf
@@ -1,0 +1,4 @@
+provider "ibm" {
+  ibmcloud_api_key = var.ibmcloud_api_key
+  region           = var.region
+}

--- a/examples/multi-profile-one-vpc/variables.tf
+++ b/examples/multi-profile-one-vpc/variables.tf
@@ -1,0 +1,47 @@
+variable "ibmcloud_api_key" {
+  description = "APIkey that's associated with the account to provision resources to"
+  type        = string
+  sensitive   = true
+}
+
+variable "resource_group" {
+  type        = string
+  description = "An existing resource group name to use for this example, if unset a new resource group will be created"
+  default     = null
+}
+
+variable "region" {
+  description = "The region to which to deploy all resources in this example"
+  type        = string
+  default     = "us-south"
+}
+
+variable "prefix" {
+  description = "The prefix that you would like to append to your resources"
+  type        = string
+  default     = "slz-vsi-com"
+}
+
+variable "resource_tags" {
+  description = "List of Tags for the resource created"
+  type        = list(string)
+  default     = []
+}
+
+variable "access_tags" {
+  type        = list(string)
+  description = "A list of access tags to apply to the VSI resources created by the module."
+  default     = []
+}
+
+variable "image_id" {
+  description = "Image ID used for VSI. Run 'ibmcloud is images' to find available images. Be aware that region is important for the image since the id's are different in each region."
+  type        = string
+  default     = "r006-88da7a09-2f59-4324-ac85-e3165f6323f5"
+}
+
+variable "ssh_key" {
+  type        = string
+  description = "An existing ssh key name to use for this example, if unset a new ssh key will be created"
+  default     = null
+}

--- a/examples/multi-profile-one-vpc/version.tf
+++ b/examples/multi-profile-one-vpc/version.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.9.0"
+  required_providers {
+    ibm = {
+      source  = "IBM-Cloud/ibm"
+      version = ">= 1.78.4"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0.4"
+    }
+  }
+}

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -22,6 +22,9 @@ const basicExampleTerraformDir = "examples/basic"
 const completeExampleTerraformDir = "examples/complete"
 const fsCloudExampleTerraformDir = "examples/fscloud"
 
+// calls vsi module twice on same subnets to check for duplicate names
+const multiModuleOneVpcTerraformDir = "examples/multi-profile-one-vpc"
+
 const snapshotExampleTerraformDir = "examples/snapshot"
 const fullyConfigFlavorDir = "solutions/fully-configurable"
 
@@ -398,4 +401,26 @@ func TestUpgradeFullyConfigurable(t *testing.T) {
 		terraform.WorkspaceDelete(t, existingTerraformOptions, prefix)
 		logger.Log(t, "END: Destroy (prereq resources)")
 	}
+}
+
+// This test will include TWO calls to the VSI module on the same VPC and subnets.
+// To plug a test gap where we found that the module prefix was not used to name some resources
+// and if deployed to same subnets would have duplicate names.
+func TestRunMultiProfileExample(t *testing.T) {
+	t.Parallel()
+
+	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
+		Testing:       t,
+		TerraformDir:  multiModuleOneVpcTerraformDir,
+		Prefix:        "slz-vsi-mp",
+		ResourceGroup: resourceGroup,
+		Region:        region,
+		TerraformVars: map[string]interface{}{
+			"access_tags": permanentResources["accessTags"],
+		},
+	})
+
+	output, err := options.RunTestConsistency()
+	assert.Nil(t, err, "This should not have errored")
+	assert.NotNil(t, output, "Expected some output")
 }


### PR DESCRIPTION
### Description

Fixes some duplicate resource naming issues when the LZ VSI module is used multiple times on the same VPC and subnets.

This patch will fix the following resources that were using subnet names only, and not taking into account the `var.prefix` supplied to the module. Due to only using subnet names and no prefix, these resources will run into duplicate name issues when the VSI module is called multiple times (usually to set up multiple machine/OS profiles) on the same set of subnets.

The resources fixed in this patch are:
- reserved IPs
- secondary reserved IPs
- secondary VNI floating IPs

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Fixes the naming of VSI related resources to make sure the names take into account the prefix supplied to the module, avoiding a duplicate name issue when module is applied several times on same set of subnets. NOTE: this should be a non-destructive change, the names of IBM Cloud IP resources will be changed in place, with no changes to the original IP value.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
