### PR TITLE
fix: add output of full vsi details

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ You need the following permissions to run this module.
 | <a name="output_lb_hostnames"></a> [lb\_hostnames](#output\_lb\_hostnames) | Hostnames for the Load Balancer created |
 | <a name="output_lb_security_groups"></a> [lb\_security\_groups](#output\_lb\_security\_groups) | Load Balancer security groups |
 | <a name="output_list"></a> [list](#output\_list) | A list of VSI with name, id, zone, and primary ipv4 address |
+| <a name="output_vsi_full_detail_map"></a> [vsi\_full\_detail\_map](#output\_vsi\_full\_detail\_map) | A list of all deployed VSI with their full detail map, organized by VSI name |
 | <a name="output_vsi_security_group"></a> [vsi\_security\_group](#output\_vsi\_security\_group) | Security group for the VSI |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -4,6 +4,6 @@ output "slz_vpc" {
 }
 
 output "slz_vsi" {
-  value       = module.slz_vsi
+  value       = module.slz_vsi.list
   description = "VSI module values"
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -4,12 +4,12 @@ output "slz_vpc" {
 }
 
 output "slz_vsi" {
-  value       = module.slz_vsi
+  value       = module.slz_vsi.list
   description = "VSI module values"
 }
 
 output "slz_vsi_dh" {
-  value       = module.slz_vsi_dh
+  value       = module.slz_vsi_dh.list
   description = "VSI module values"
 }
 

--- a/examples/fscloud/outputs.tf
+++ b/examples/fscloud/outputs.tf
@@ -4,6 +4,6 @@ output "slz_vpc" {
 }
 
 output "slz_vsi" {
-  value       = module.slz_vsi
+  value       = module.slz_vsi.list
   description = "VSI module values"
 }

--- a/examples/multi-profile-one-vpc/outputs.tf
+++ b/examples/multi-profile-one-vpc/outputs.tf
@@ -4,12 +4,12 @@ output "slz_vpc" {
 }
 
 output "slz_vsi_cx" {
-  value       = module.slz_vsi_cx
+  value       = module.slz_vsi_cx.list
   description = "VSI cx profile module values"
 }
 
 output "slz_vsi_bx" {
-  value       = module.slz_vsi_bx
+  value       = module.slz_vsi_bx.list
   description = "VSI bx profile module values"
 }
 

--- a/examples/snapshot/outputs.tf
+++ b/examples/snapshot/outputs.tf
@@ -4,6 +4,6 @@ output "slz_vpc" {
 }
 
 output "slz_vsi" {
-  value       = module.slz_vsi
+  value       = module.slz_vsi.list
   description = "VSI module values"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,6 +34,11 @@ output "list" {
   ]
 }
 
+output "full_vsi_detail_map" {
+  description = "A list of all deployed VSI with their full detail map, organized by VSI name"
+  value       = { for vsi_key, virtual_server in ibm_is_instance.vsi : virtual_server.name => virtual_server }
+}
+
 output "fip_list" {
   description = "A list of VSI with name, id, zone, and primary ipv4 address, and floating IP. This list only contains instances with a floating IP attached."
   value = [

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,6 +37,7 @@ output "list" {
 output "vsi_full_detail_map" {
   description = "A list of all deployed VSI with their full detail map, organized by VSI name"
   value       = { for vsi_key, virtual_server in ibm_is_instance.vsi : virtual_server.name => virtual_server }
+  sensitive   = true
 }
 
 output "fip_list" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,7 +34,7 @@ output "list" {
   ]
 }
 
-output "full_vsi_detail_map" {
+output "vsi_full_detail_map" {
   description = "A list of all deployed VSI with their full detail map, organized by VSI name"
   value       = { for vsi_key, virtual_server in ibm_is_instance.vsi : virtual_server.name => virtual_server }
 }


### PR DESCRIPTION
### Description

Added a new module output `vsi_full_detail_map` that contains all post-deploy details of all VSIs, organized by VSI hostname.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
