### PR TITLE
fix: added network interface details to outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -20,16 +20,18 @@ output "list" {
   value = [
     for vsi_key, virtual_server in ibm_is_instance.vsi :
     {
-      name                   = virtual_server.name
-      id                     = virtual_server.id
-      zone                   = virtual_server.zone
-      ipv4_address           = virtual_server.primary_network_interface[0].primary_ipv4_address
-      secondary_ipv4_address = length(virtual_server.network_interfaces) == 0 ? null : virtual_server.network_interfaces[0].primary_ipv4_address
-      floating_ip            = var.enable_floating_ip ? ibm_is_floating_ip.vsi_fip[vsi_key].address : null
-      floating_ip_id         = var.enable_floating_ip ? ibm_is_floating_ip.vsi_fip[vsi_key].id : null
-      floating_ip_crn        = var.enable_floating_ip ? ibm_is_floating_ip.vsi_fip[vsi_key].crn : null
-      vpc_id                 = var.vpc_id
-      snapshot_id            = one(virtual_server.boot_volume[*].snapshot)
+      name                               = virtual_server.name
+      id                                 = virtual_server.id
+      zone                               = virtual_server.zone
+      ipv4_address                       = virtual_server.primary_network_interface[0].primary_ip[0].address
+      primary_network_interface_detail   = virtual_server.primary_network_interface[0]
+      secondary_ipv4_address             = length(virtual_server.network_interfaces) == 0 ? null : virtual_server.network_interfaces[0].primary_ip[0].address
+      secondary_network_interface_detail = length(virtual_server.network_interfaces) == 0 ? null : virtual_server.network_interfaces[0]
+      floating_ip                        = var.enable_floating_ip ? ibm_is_floating_ip.vsi_fip[vsi_key].address : null
+      floating_ip_id                     = var.enable_floating_ip ? ibm_is_floating_ip.vsi_fip[vsi_key].id : null
+      floating_ip_crn                    = var.enable_floating_ip ? ibm_is_floating_ip.vsi_fip[vsi_key].crn : null
+      vpc_id                             = var.vpc_id
+      snapshot_id                        = one(virtual_server.boot_volume[*].snapshot)
     }
   ]
 }
@@ -39,15 +41,17 @@ output "fip_list" {
   value = [
     for vsi_key, virtual_server in ibm_is_instance.vsi :
     {
-      name                   = virtual_server.name
-      id                     = virtual_server.id
-      zone                   = virtual_server.zone
-      ipv4_address           = virtual_server.primary_network_interface[0].primary_ipv4_address
-      secondary_ipv4_address = length(virtual_server.network_interfaces) == 0 ? null : virtual_server.network_interfaces[0].primary_ipv4_address
-      floating_ip            = var.enable_floating_ip ? ibm_is_floating_ip.vsi_fip[vsi_key].address : null
-      floating_ip_id         = var.enable_floating_ip ? ibm_is_floating_ip.vsi_fip[vsi_key].id : null
-      floating_ip_crn        = var.enable_floating_ip ? ibm_is_floating_ip.vsi_fip[vsi_key].crn : null
-      vpc_id                 = var.vpc_id
+      name                               = virtual_server.name
+      id                                 = virtual_server.id
+      zone                               = virtual_server.zone
+      ipv4_address                       = virtual_server.primary_network_interface[0].primary_ip[0].address
+      primary_network_interface_detail   = virtual_server.primary_network_interface[0]
+      secondary_ipv4_address             = length(virtual_server.network_interfaces) == 0 ? null : virtual_server.network_interfaces[0].primary_ip[0].address
+      secondary_network_interface_detail = length(virtual_server.network_interfaces) == 0 ? null : virtual_server.network_interfaces[0]
+      floating_ip                        = var.enable_floating_ip ? ibm_is_floating_ip.vsi_fip[vsi_key].address : null
+      floating_ip_id                     = var.enable_floating_ip ? ibm_is_floating_ip.vsi_fip[vsi_key].id : null
+      floating_ip_crn                    = var.enable_floating_ip ? ibm_is_floating_ip.vsi_fip[vsi_key].crn : null
+      vpc_id                             = var.vpc_id
     } if var.enable_floating_ip == true
   ]
 }


### PR DESCRIPTION
### Description

Added the following network details to the existing outputs `list` and `fip_list`:
- primary_network_interface_detail
- secondary_network_interface_detail

Also changed the deprecated `primary_ipv4_address` to `primary_ip[0].address` in the same output maps.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
