### PR TITLE
fix: vni secondary security groups not aligned to subnets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -161,13 +161,13 @@ resource "ibm_is_virtual_network_interface" "secondary_vni" {
     (var.create_security_group && var.secondary_use_vsi_security_group ? [ibm_is_security_group.security_group[var.security_group.name].id] : []),
     [
       for group in var.secondary_security_groups :
-      group.security_group_id if group.interface_name == each.value.name
+      group.security_group_id if group.interface_name == each.value.subnet_name
     ]
     ])) == 0 ? [data.ibm_is_vpc.vpc.default_security_group] : flatten([
     (var.create_security_group && var.secondary_use_vsi_security_group ? [ibm_is_security_group.security_group[var.security_group.name].id] : []),
     [
       for group in var.secondary_security_groups :
-      group.security_group_id if group.interface_name == each.value.name
+      group.security_group_id if group.interface_name == each.value.subnet_name
     ]
   ])
   auto_delete               = false

--- a/variables.tf
+++ b/variables.tf
@@ -528,11 +528,6 @@ variable "secondary_security_groups" {
     error_message = "Security group IDs must be unique."
     condition     = length(var.secondary_security_groups) == length(distinct(var.secondary_security_groups))
   }
-
-  validation {
-    error_message = "No more than 5 security groups can be added to a VSI deployment."
-    condition     = length(var.secondary_security_groups) <= 5
-  }
 }
 
 variable "secondary_floating_ips" {


### PR DESCRIPTION
### Description

Fixing a bug from when the new VNI option was introduced, the secondary security groups were not using the correct value to match `var.secondary_security_groups` to the correct VNI.

The correct usage from the user side should be to match `var.secondary_subnets.name` with `var.secondary_security_groups.interface_name`, this PR will fix a bug where we were not using that same mapping when we assign the groups to VNI (classic network interface was working correctly).

Also removed an old validation that restricted the `var.secondary_security_groups` length to <=5, that rule had applied for the old classic network interface, but now that VNIs have been introduced this simple rule will not apply in the same way.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
