### PR TITLE
chore: update the default VSI image IDs

### DIFF
--- a/tests/existing-resources/variables.tf
+++ b/tests/existing-resources/variables.tf
@@ -33,6 +33,6 @@ variable "resource_tags" {
 
 variable "image_name" {
   type        = string
-  default     = "ibm-ubuntu-24-04-2-minimal-amd64-5"
+  default     = "ibm-ubuntu-24-04-3-minimal-amd64-1"
   description = "Image name to retrive the image ID for that region."
 }


### PR DESCRIPTION
Update VSI image name variable defaults to ibm-redhat-9-6-minimal-amd64-3